### PR TITLE
fix: 랜딩 페이지 랭킹 프리뷰 쿼리 실패 상태 처리 추가

### DIFF
--- a/src/app/(home)/_components/RankingTabSection.tsx
+++ b/src/app/(home)/_components/RankingTabSection.tsx
@@ -58,7 +58,14 @@ export default function RankingTabSection() {
       </div>
 
       <div className="grid grid-cols-5 gap-3">
-        {results.isPending
+        {results.isError ? (
+          <div className="col-span-5 flex flex-col items-center justify-center gap-2 py-8 text-center">
+            <p className="text-sm text-muted-foreground">정보를 불러오지 못했습니다.</p>
+            <button onClick={() => results.refetch()} className="text-xs text-[#7F77DD] hover:underline">
+              다시 시도
+            </button>
+          </div>
+        ) : results.isPending
           ? Array.from({ length: 5 }).map((_, i) => (
               <div key={i} className="aspect-[2/3] rounded-lg bg-slate-300 dark:bg-slate-800 animate-pulse" />
             ))

--- a/src/app/(home)/_components/Top5Section.tsx
+++ b/src/app/(home)/_components/Top5Section.tsx
@@ -32,7 +32,14 @@ export default function Top5Section() {
     <div className="w-full">
       <h2 className="text-xl font-bold mb-4">지금 방영 중 TOP 5</h2>
       <div className="grid grid-cols-5 gap-3">
-        {data.length > 0
+        {results.isError ? (
+          <div className="col-span-5 flex flex-col items-center justify-center gap-2 py-8 text-center">
+            <p className="text-sm text-muted-foreground">정보를 불러오지 못했습니다.</p>
+            <button onClick={() => results.refetch()} className="text-xs text-[#7F77DD] hover:underline">
+              다시 시도
+            </button>
+          </div>
+        ) : data.length > 0
           ? data.map(({ node }, i) => (
               <Link
                 key={node.id}


### PR DESCRIPTION
Top5Section, RankingTabSection에서 results.isError를 확인하지 않아 쿼리 실패 시 빈 데이터로 폴백되어 스켈레톤이 계속 보이거나
빈 그리드만 표시되던 문제 수정. 에러 메시지와 다시 시도 버튼 추가.

Closes #58