### PR TITLE
fix: 상세 페이지 관련 이미지 링크에 접근 가능한 이름 추가

### DIFF
--- a/src/app/(with-navigation)/details/[id]/_components/ui/RelatedImages.tsx
+++ b/src/app/(with-navigation)/details/[id]/_components/ui/RelatedImages.tsx
@@ -15,11 +15,12 @@ export default function RelatedImages({ pictures }: { pictures: Picture[] }) {
             href={p.large ?? p.medium}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`관련 이미지 ${idx + 1} (새 탭에서 열기)`}
             className="relative aspect-[3/4] rounded-md overflow-hidden bg-slate-300 dark:bg-slate-800"
           >
             <Image
               src={p.large ?? p.medium}
-              alt=""
+              alt={`관련 이미지 ${idx + 1}`}
               fill
               className="object-cover"
               sizes="(max-width: 768px) 20vw, 12vw"


### PR DESCRIPTION
alt=""로 인해 각 이미지 새 탭 링크가 스크린 리더에서 이름 없이
노출되던 문제 수정. Link에 aria-label, Image에 설명 alt 텍스트 추가.

Closes #62